### PR TITLE
Add docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,46 @@ Example output format
 2020-08-03 19:04:35 example.com 192.168.200.56 GET /admin/ HTTP/1.1 404 0 0.000482654 http://example.com/admin/ "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0"
 ```
 
+For an example of a goaccess configuration that is compatible with the output format, see the `goaccess.conf` file
+
+
+## Docker Image
+
+A docker image is also provided.
+
+Example `docker-compose`:
+
+```
+version: "3.7"
+
+services:
+  caddy:
+    image: caddy:2.1.1-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./site:/srv
+      - ./caddy_data:/data
+      - ./caddy_config:/config
+
+  logconverter:
+    build:
+      context: ./logconverter
+      dockerfile: dockerfile
+    volumes:
+      - ./caddy_data:/logconverter/input-logs
+      - ./site/logs:/logconverter/output-logs
+
+```
+
+In the example above, Caddy is set to output logs to the /data folder. Excerpt from Caddyfile:
+
+```
+	log {
+		output file /data/access.log
+	}
+
+```

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,16 @@
+FROM python:3-alpine
+
+
+WORKDIR /logconverter
+RUN mkdir -pv /logconverter/input-logs &&\ 
+    mkdir -pv /logconverter/output-logs &&\ 
+    chmod -R 777 /logconverter/output-logs  &&\
+    apk add goaccess && \
+    wget https://github.com/UbuntuEvangelist/GeoLiteCity.dat.gz/raw/master/GeoLiteCity.dat.gz &&\
+    gunzip GeoLiteCity.dat.gz
+
+COPY ["caddyLog.py", "entrypoint.sh", "LICENSE", "goaccess.conf", "./"]
+
+VOLUME [ "/logconverter/input-logs", "/logconverter/output-logs" ]
+
+ENTRYPOINT ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "Ready"
+while true
+do 
+    echo "Convert logs..."
+    python ./caddyLog.py -i ./input-logs/access.log -g ./output-logs/access.log
+    echo "Generate report..."
+    goaccess --config-file=./goaccess.conf
+    echo "Report genrated."
+    sleep 600
+done
+echo "Exited."

--- a/goaccess.conf
+++ b/goaccess.conf
@@ -1,0 +1,6 @@
+time-format %H:%M:%S
+date-format %Y-%m-%d
+log-format %d %t %v %h %m %U %H %s %b %L %R %u
+log-file /logconverter/output-logs/access.log
+output /logconverter/output-logs/index.html
+geoip-database /logconverter/GeoLiteCity.dat


### PR DESCRIPTION
This allows CaddyGoAccessDataLoggerConverter to be run inside a container.
The container image itself contains both the log converter and GoAccess and is set run the conversion and report generation every 10 minutes.

Initially I intended to have this be in its own container separate from GoAccess but I've had to include it because the GoAccess docker image [is broken at the moment when generating real time html](https://github.com/allinurl/goaccess/issues/1925)

I also included a `goaccess.conf` file that can be used as a starting point and is included in the final docker image. 